### PR TITLE
Always use python2 interpreter

### DIFF
--- a/msrsync
+++ b/msrsync
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # Copyright 2017 Jean-Baptiste Denis <jbd@jbdenis.net>


### PR DESCRIPTION
Hi,
I can see that a python3 version is beeing worked on already. Since this version does only work for python2 python2 should also be used, no matter which interpreter is the system default. 